### PR TITLE
Fix pluralization syntax in en.yml

### DIFF
--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -51,13 +51,13 @@ fof-ban-ips:
       save_button: Save
 
       ban_ip_confirmation: "Are you sure you want to block this IP address from use on the forum? This will block users with this IP address(es) from logging in and registering."
-      ban_ip_users: "{count, plural, one {User {users} will be banned}, other {Users {users} will be banned}}"
+      ban_ip_users: "{count, plural, one {User {users} will be banned} other {Users {users} will be banned}}"
 
       unban_ip_confirmation: Are you sure you want to unban this user and all other users not banned by other IPs?
       unban_options_only_ip: Only unban current IP (<code>{ip}</code>)
       unban_options_all_ip: Unban all IPs used by <i>{username}</i>
       unban_ip_no_users: No one else will be unbanned
-      unban_ip_users: "{count, plural, one {User {users} will be unbanned}, other {Users {users} will be unbanned}}"
+      unban_ip_users: "{count, plural, one {User {users} will be unbanned} other {Users {users} will be unbanned}}"
       unbanned_ips: Unbanned <code>{ips}</code>.
 
       ban_button: => fof-ban-ips.ref.ban_label


### PR DESCRIPTION
I'm not sure if old syntax works in Flarum, but there should be no comma between variants, and Weblate or https://format-message.github.io/icu-message-format-for-translators/editor.html report this as error.