### PR TITLE
Add API endpoint tests and fix permission bugs they uncovered

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -8,6 +8,6 @@ jobs:
     with:
       enable_backend_testing: true
       enable_phpstan: true
-      php_versions: '["8.0", "8.1", "8.2"]'
+      php_versions: '["8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]'
 
       backend_directory: .

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ composer require fof/ban-ips:"*"
 ### Updating
 
 ```sh
-composer update fof/ban-ips:"*"
+composer update fof/ban-ips
 ```
 
 ### Links

--- a/src/Api/Controllers/CheckIPsController.php
+++ b/src/Api/Controllers/CheckIPsController.php
@@ -78,14 +78,18 @@ class CheckIPsController extends AbstractListController
         $actor = RequestUtil::getActor($request);
         $params = $request->getQueryParams();
 
-        $actor->assertCan('banIP');
+        $actor->assertPermission($actor->hasPermission('fof.ban-ips.banIP'));
 
         $userId = Arr::get($params, 'user');
         $ip = Arr::get($params, 'ip');
 
         $user = $userId != null ? User::where('id', $userId)->orWhere('username', $userId)->first() : null;
 
-        $actor->assertCan('banIP', $user);
+        // When a specific user is targeted, enforce the per-user policy (e.g. cannot target
+        // yourself or another user who also holds the ban permission).
+        if ($user !== null) {
+            $actor->assertCan('banIP', $user);
+        }
 
         if (!isset($ip) && !isset($user)) {
             throw new RouteNotFoundException();

--- a/src/Api/Controllers/ListBannedIPsController.php
+++ b/src/Api/Controllers/ListBannedIPsController.php
@@ -71,7 +71,7 @@ class ListBannedIPsController extends AbstractListController
          */
         $actor = RequestUtil::getActor($request);
 
-        $actor->assertCan('fof.banips.viewBannedIPList');
+        $actor->assertCan('fof.ban-ips.viewBannedIPList');
 
         $filters = $this->extractFilter($request);
         $sort = $this->extractSort($request);

--- a/src/Api/Controllers/ListUserBannedIPsController.php
+++ b/src/Api/Controllers/ListUserBannedIPsController.php
@@ -57,7 +57,7 @@ class ListUserBannedIPsController extends AbstractListController
          */
         $actor = RequestUtil::getActor($request);
 
-        $actor->assertCan('fof.banips.viewBannedIPList');
+        $actor->assertCan('fof.ban-ips.viewBannedIPList');
 
         $id = Arr::get($request->getQueryParams(), 'id');
         $user = User::where('id', $id)->orWhere('username', $id)->firstOrFail();

--- a/src/Commands/DeleteBannedIPHandler.php
+++ b/src/Commands/DeleteBannedIPHandler.php
@@ -33,7 +33,7 @@ class DeleteBannedIPHandler
          */
         $actor = $command->actor;
 
-        $actor->assertCan('banIP');
+        $actor->assertPermission($actor->hasPermission('fof.ban-ips.banIP'));
 
         $banIP = $this->bannedIPs->findOrFail($command->bannedId);
 

--- a/src/Commands/EditBannedIPHandler.php
+++ b/src/Commands/EditBannedIPHandler.php
@@ -51,9 +51,9 @@ class EditBannedIPHandler
         /** @var BannedIP $bannedIP */
         $bannedIP = BannedIP::find($command->bannedId);
 
-        $actor->assertCan('banIP');
+        $actor->assertPermission($actor->hasPermission('fof.ban-ips.banIP'));
 
-        if ($bannedIP !== null && $actor === $bannedIP->creator) {
+        if ($bannedIP !== null && $actor->id === $bannedIP->creator_id) {
             throw new PermissionDeniedException();
         } elseif ($bannedIP == null) {
             throw new RouteNotFoundException();

--- a/tests/integration/api/BanUserControllerTest.php
+++ b/tests/integration/api/BanUserControllerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of fof/ban-ips.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\BanIPs\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use FoF\BanIPs\BannedIP;
+use FoF\BanIPs\Tests\fixtures\IPAddressesTrait;
+
+class BanUserControllerTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+    use IPAddressesTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-ban-ips');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'moderator', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'moderator@machine.local', 'is_email_confirmed' => 1, 'last_seen_at' => Carbon::now()->subSecond()],
+                ['id' => 5, 'username' => 'target', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'target@machine.local', 'is_email_confirmed' => 1, 'last_seen_at' => Carbon::now()->subSecond()],
+            ],
+            'group_user' => [
+                ['group_id' => 4, 'user_id' => 3],
+            ],
+            'group_permission' => [
+                ['group_id' => 4, 'permission' => 'fof.ban-ips.banIP'],
+                ['group_id' => 4, 'permission' => 'fof.ban-ips.viewBannedIPList'],
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 5, 'first_post_id' => 1, 'comment_count' => 2],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 5, 'type' => 'comment', 'content' => '<t><p>foo</p></t>', 'ip_address' => $this->getIPv4NotBanned()[0]],
+                ['id' => 2, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 5, 'type' => 'comment', 'content' => '<t><p>bar</p></t>', 'ip_address' => $this->getIPv6NotBanned()[0]],
+            ],
+            'banned_ips' => $this->getBannedIPsForDB(),
+        ]);
+    }
+
+    public function test_user_with_permission_can_ban_a_user()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/users/5/ban', [
+                'authenticatedAs' => 3,
+                'json'            => [
+                    'data' => [
+                        'attributes' => [
+                            'reason' => 'Spammer',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+
+        // Both of the target's post IPs should now be banned and associated with the user.
+        $banned = BannedIP::where('user_id', 5)->pluck('address')->toArray();
+        $this->assertContains($this->getIPv4NotBanned()[0], $banned);
+        $this->assertContains($this->getIPv6NotBanned()[0], $banned);
+    }
+
+    public function test_user_without_permission_cannot_ban_a_user()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/users/5/ban', [
+                'authenticatedAs' => 2,
+                'json'            => [
+                    'data' => [
+                        'attributes' => [
+                            'reason' => 'Spammer',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(0, BannedIP::where('user_id', 5)->count());
+    }
+
+    public function test_user_cannot_ban_themselves()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/users/3/ban', [
+                'authenticatedAs' => 3,
+                'json'            => [
+                    'data' => [
+                        'attributes' => [
+                            'reason' => 'Spammer',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    public function test_user_cannot_ban_another_user_with_ban_permission()
+    {
+        // User 1 is the admin, who bypasses all permission checks and so is "privileged".
+        $response = $this->send(
+            $this->request('POST', '/api/users/1/ban', [
+                'authenticatedAs' => 3,
+                'json'            => [
+                    'data' => [
+                        'attributes' => [
+                            'reason' => 'Spammer',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+}

--- a/tests/integration/api/CheckIPsControllerTest.php
+++ b/tests/integration/api/CheckIPsControllerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of fof/ban-ips.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\BanIPs\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use FoF\BanIPs\Tests\fixtures\IPAddressesTrait;
+
+class CheckIPsControllerTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+    use IPAddressesTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-ban-ips');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'moderator', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'moderator@machine.local', 'is_email_confirmed' => 1, 'last_seen_at' => Carbon::now()->subSecond()],
+                ['id' => 5, 'username' => 'poster', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'poster@machine.local', 'is_email_confirmed' => 1, 'last_seen_at' => Carbon::now()->subSecond()],
+            ],
+            'group_user' => [
+                ['group_id' => 4, 'user_id' => 3],
+            ],
+            'group_permission' => [
+                ['group_id' => 4, 'permission' => 'fof.ban-ips.banIP'],
+                ['group_id' => 4, 'permission' => 'fof.ban-ips.viewBannedIPList'],
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => __CLASS__, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 5, 'first_post_id' => 1, 'comment_count' => 1],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'created_at' => Carbon::now(), 'user_id' => 5, 'type' => 'comment', 'content' => '<t><p>foo</p></t>', 'ip_address' => $this->getIPv4NotBanned()[0]],
+            ],
+        ]);
+    }
+
+    public function test_user_with_permission_can_check_users_by_ip()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/fof/ban-ips/check-users', [
+                'authenticatedAs' => 3,
+            ])->withQueryParams(['ip' => $this->getIPv4NotBanned()[0]])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+
+        // User 5 posted from this IP and has no ban permission, so they should be returned.
+        $ids = array_map(fn ($u) => (int) $u['id'], json_decode((string) $response->getBody(), true)['data']);
+        $this->assertContains(5, $ids);
+    }
+
+    public function test_user_without_permission_cannot_check_users()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/fof/ban-ips/check-users', [
+                'authenticatedAs' => 2,
+            ])->withQueryParams(['ip' => $this->getIPv4NotBanned()[0]])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    public function test_invalid_ip_is_rejected()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/fof/ban-ips/check-users', [
+                'authenticatedAs' => 3,
+            ])->withQueryParams(['ip' => 'not-an-ip'])
+        );
+
+        $this->assertEquals(422, $response->getStatusCode());
+    }
+}

--- a/tests/integration/api/DeleteBannedIPControllerTest.php
+++ b/tests/integration/api/DeleteBannedIPControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of fof/ban-ips.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\BanIPs\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use FoF\BanIPs\BannedIP;
+use FoF\BanIPs\Tests\fixtures\IPAddressesTrait;
+
+class DeleteBannedIPControllerTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+    use IPAddressesTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-ban-ips');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'moderator', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'moderator@machine.local', 'is_email_confirmed' => 1, 'last_seen_at' => Carbon::now()->subSecond()],
+            ],
+            'group_user' => [
+                ['group_id' => 4, 'user_id' => 3],
+            ],
+            'group_permission' => [
+                ['group_id' => 4, 'permission' => 'fof.ban-ips.banIP'],
+                ['group_id' => 4, 'permission' => 'fof.ban-ips.viewBannedIPList'],
+            ],
+            'banned_ips' => $this->getBannedIPsForDB(),
+        ]);
+    }
+
+    public function test_admin_can_delete_a_banned_ip()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/fof/ban-ips/1', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertNull(BannedIP::find(1));
+    }
+
+    public function test_user_with_permission_can_delete_a_banned_ip()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/fof/ban-ips/2', [
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode(), (string) $response->getBody());
+        $this->assertNull(BannedIP::find(2));
+    }
+
+    public function test_user_without_permission_cannot_delete_a_banned_ip()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/fof/ban-ips/1', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertNotNull(BannedIP::find(1));
+    }
+}

--- a/tests/integration/api/ListBannedIPsControllerTest.php
+++ b/tests/integration/api/ListBannedIPsControllerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of fof/ban-ips.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\BanIPs\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use FoF\BanIPs\Tests\fixtures\IPAddressesTrait;
+
+class ListBannedIPsControllerTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+    use IPAddressesTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-ban-ips');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'moderator', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'moderator@machine.local', 'is_email_confirmed' => 1, 'last_seen_at' => Carbon::now()->subSecond()],
+            ],
+            'group_user' => [
+                ['group_id' => 4, 'user_id' => 3],
+            ],
+            'group_permission' => [
+                ['group_id' => 4, 'permission' => 'fof.ban-ips.viewBannedIPList'],
+            ],
+            'banned_ips' => $this->getBannedIPsForDB(),
+        ]);
+    }
+
+    public function test_admin_can_list_banned_ips()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/fof/ban-ips', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+
+        $data = json_decode((string) $response->getBody(), true)['data'];
+        $this->assertCount(count($this->getAllBanned()), $data);
+    }
+
+    /**
+     * A user granted only `fof.ban-ips.viewBannedIPList` (not an admin) must be able to
+     * view the list. This guards against the permission key being checked under the wrong name.
+     */
+    public function test_user_with_view_permission_can_list_banned_ips()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/fof/ban-ips', [
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+    }
+
+    public function test_user_without_permission_cannot_list_banned_ips()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/fof/ban-ips', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+}

--- a/tests/integration/api/UnbanUserControllerTest.php
+++ b/tests/integration/api/UnbanUserControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of fof/ban-ips.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\BanIPs\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use FoF\BanIPs\BannedIP;
+use FoF\BanIPs\Tests\fixtures\IPAddressesTrait;
+
+class UnbanUserControllerTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+    use IPAddressesTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-ban-ips');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+                // The fixture associates every banned IP with user_id 3, so user 3 is the banned user.
+                ['id' => 3, 'username' => 'ipBanned', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'ipbanned@machine.local', 'is_email_confirmed' => 1, 'last_seen_at' => Carbon::now()->subSecond()],
+                ['id' => 4, 'username' => 'moderator', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'moderator@machine.local', 'is_email_confirmed' => 1, 'last_seen_at' => Carbon::now()->subSecond()],
+            ],
+            'group_user' => [
+                ['group_id' => 4, 'user_id' => 4],
+            ],
+            'group_permission' => [
+                ['group_id' => 4, 'permission' => 'fof.ban-ips.banIP'],
+                ['group_id' => 4, 'permission' => 'fof.ban-ips.viewBannedIPList'],
+            ],
+            'banned_ips' => $this->getBannedIPsForDB(),
+        ]);
+    }
+
+    public function test_user_with_permission_can_unban_a_user()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/users/3/unban', [
+                'authenticatedAs' => 4,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+
+        // Every banned IP associated with the user should have been removed.
+        $this->assertEquals(0, BannedIP::where('user_id', 3)->count());
+    }
+
+    public function test_user_without_permission_cannot_unban_a_user()
+    {
+        $response = $this->send(
+            $this->request('POST', '/api/users/3/unban', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertGreaterThan(0, BannedIP::where('user_id', 3)->count());
+    }
+}

--- a/tests/integration/api/UpdateBannedIPControllerTest.php
+++ b/tests/integration/api/UpdateBannedIPControllerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of fof/ban-ips.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\BanIPs\Tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use FoF\BanIPs\BannedIP;
+use FoF\BanIPs\Tests\fixtures\IPAddressesTrait;
+
+class UpdateBannedIPControllerTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+    use IPAddressesTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-ban-ips');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'moderator', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'moderator@machine.local', 'is_email_confirmed' => 1, 'last_seen_at' => Carbon::now()->subSecond()],
+            ],
+            'group_user' => [
+                ['group_id' => 4, 'user_id' => 3],
+            ],
+            'group_permission' => [
+                ['group_id' => 4, 'permission' => 'fof.ban-ips.banIP'],
+                ['group_id' => 4, 'permission' => 'fof.ban-ips.viewBannedIPList'],
+            ],
+            // Ban #1 was created by the admin, ban #2 by the moderator (user 3).
+            // A ban's creator may not edit their own ban.
+            'banned_ips' => [
+                ['id' => 1, 'creator_id' => 1, 'user_id' => 2, 'address' => $this->getIPv4Banned()[0], 'reason' => 'Original', 'created_at' => Carbon::now()],
+                ['id' => 2, 'creator_id' => 3, 'user_id' => 2, 'address' => $this->getIPv4Banned()[1], 'reason' => 'Original', 'created_at' => Carbon::now()],
+            ],
+        ]);
+    }
+
+    public function test_user_with_permission_can_edit_the_reason()
+    {
+        $response = $this->send(
+            $this->request('PATCH', '/api/fof/ban-ips/1', [
+                'authenticatedAs' => 3,
+                'json'            => [
+                    'data' => [
+                        'attributes' => [
+                            'reason' => 'Updated reason',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+        $this->assertEquals('Updated reason', BannedIP::find(1)->reason);
+    }
+
+    public function test_admin_can_edit_the_reason()
+    {
+        $response = $this->send(
+            $this->request('PATCH', '/api/fof/ban-ips/2', [
+                'authenticatedAs' => 1,
+                'json'            => [
+                    'data' => [
+                        'attributes' => [
+                            'reason' => 'Updated by admin',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode(), (string) $response->getBody());
+        $this->assertEquals('Updated by admin', BannedIP::find(2)->reason);
+    }
+
+    public function test_creator_cannot_edit_their_own_ban()
+    {
+        // The moderator (user 3) created ban #2.
+        $response = $this->send(
+            $this->request('PATCH', '/api/fof/ban-ips/2', [
+                'authenticatedAs' => 3,
+                'json'            => [
+                    'data' => [
+                        'attributes' => [
+                            'reason' => 'Updated reason',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals('Original', BannedIP::find(2)->reason);
+    }
+
+    public function test_user_without_permission_cannot_edit_a_ban()
+    {
+        $response = $this->send(
+            $this->request('PATCH', '/api/fof/ban-ips/1', [
+                'authenticatedAs' => 2,
+                'json'            => [
+                    'data' => [
+                        'attributes' => [
+                            'reason' => 'Updated reason',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    public function test_editing_a_missing_ban_returns_not_found()
+    {
+        $response = $this->send(
+            $this->request('PATCH', '/api/fof/ban-ips/9999', [
+                'authenticatedAs' => 3,
+                'json'            => [
+                    'data' => [
+                        'attributes' => [
+                            'reason' => 'Updated reason',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Why

Until now only the `BannedIPRepository`, the register/login middleware, and the **create** endpoint had integration coverage. The remaining write-path API endpoints (ban user, unban user, delete, edit, list, check-users) were untested. Adding that coverage surfaced three authorization bugs, which are fixed here.

## New tests

| File | Coverage |
|---|---|
| `BanUserControllerTest` | Ban a user's IPs; permission denied for non-privileged users; **cannot ban yourself**; **cannot ban another user who also holds the ban permission** (`UserPolicy` rules) |
| `UnbanUserControllerTest` | Unbanning a user removes all of their associated bans; permission denied |
| `DeleteBannedIPControllerTest` | Admin can delete a ban; a permission holder can delete a ban; permission denied |
| `UpdateBannedIPControllerTest` | A permission holder can edit a ban's reason; admin can edit; **a ban's creator cannot edit their own ban**; permission denied; missing ban → 404 |
| `ListBannedIPsControllerTest` | Admin can list; **a non-admin with `viewBannedIPList` can list**; permission denied |
| `CheckIPsControllerTest` | A permission holder can check users by IP; permission denied; invalid IP → 422 |

## Bugs uncovered & fixed

### 1. `viewBannedIPList` permission key typo
`ListBannedIPsController` and `ListUserBannedIPsController` asserted `fof.banips.viewBannedIPList` (no hyphen), while the permission registered everywhere else is `fof.ban-ips.viewBannedIPList`. Because no group ever holds the misspelled key, **only admins could view the banned-IP list** — a moderator granted the view permission was silently denied. Fixed both controllers to use the correct key.

### 2. Model-less `assertCan('banIP')` was effectively admin-only
`DeleteBannedIPHandler`, `EditBannedIPHandler`, and `CheckIPsController` called `$actor->assertCan('banIP')` with **no user model**. The `banIP` ability is defined by a *model* policy (`UserPolicy`), so a model-less check never routes through it and falls back to a literal `banIP` permission that no group holds — meaning **only admins could delete/edit bans or check users**, even with the `fof.ban-ips.banIP` permission.

Replaced those calls with `$actor->assertPermission($actor->hasPermission('fof.ban-ips.banIP'))`, which checks the real permission (and still bypasses for admins). In `CheckIPsController` the per-user policy check (`assertCan('banIP', $user)`) now runs only when a specific target user is resolved, so IP-only checks work for permission holders while the self/privileged-target protections remain when a user is targeted.

### 3. Creator check used object identity
`EditBannedIPHandler` guarded the "a ban's creator cannot edit their own ban" rule with `$actor === $bannedIP->creator`. `$bannedIP->creator` is a freshly-loaded model and is never the same instance as `$actor`, so the comparison was always false and **the rule never fired** — the creator could always edit. Changed to compare by id: `$actor->id === $bannedIP->creator_id`.

## Other changes

- CI: expand the backend PHP test matrix to include 8.3, 8.4 and 8.5.
- README: correct the update command (`composer update fof/ban-ips`).