### PR TITLE
Set banned_ips as a relation instead of a model attribute

### DIFF
--- a/src/Listeners/BannedIPData.php
+++ b/src/Listeners/BannedIPData.php
@@ -15,6 +15,7 @@ use Flarum\Api\Controller\AbstractSerializeController;
 use Flarum\Http\RequestUtil;
 use Flarum\User\User;
 use FoF\BanIPs\Repositories\BannedIPRepository;
+use Illuminate\Database\Eloquent\Collection;
 use Psr\Http\Message\ServerRequestInterface;
 
 class BannedIPData
@@ -38,7 +39,11 @@ class BannedIPData
     {
         $canView = RequestUtil::getActor($request)->can('fof.ban-ips.viewBannedIPList');
 
-        $data['banned_ips'] = $canView ? $this->bannedIPs->getUserBannedIPs($data)->get() : [];
+        // Set as a loaded relation rather than an attribute. Assigning via array access
+        // (`$data['banned_ips'] = ...`) would store it in the model's attributes, causing a
+        // later `$data->save()` by another extension to attempt to persist a non-existent
+        // `banned_ips` column.
+        $data->setRelation('banned_ips', $canView ? $this->bannedIPs->getUserBannedIPs($data)->get() : new Collection());
 
         return $data;
     }

--- a/src/Listeners/BannedIPsData.php
+++ b/src/Listeners/BannedIPsData.php
@@ -15,6 +15,7 @@ use Flarum\Api\Controller\AbstractListController;
 use Flarum\Http\RequestUtil;
 use Flarum\User\User;
 use FoF\BanIPs\Repositories\BannedIPRepository;
+use Illuminate\Database\Eloquent\Collection;
 use Psr\Http\Message\ServerRequestInterface;
 
 class BannedIPsData
@@ -38,8 +39,12 @@ class BannedIPsData
     {
         $canView = RequestUtil::getActor($request)->can('fof.ban-ips.viewBannedIPList');
 
+        // Set as a loaded relation rather than an attribute. Assigning via array access
+        // (`$d['banned_ips'] = ...`) would store it in the model's attributes, causing a
+        // later `$d->save()` by another extension to attempt to persist a non-existent
+        // `banned_ips` column.
         foreach ($data as $d) {
-            $d['banned_ips'] = $canView ? $this->bannedIPs->getUserBannedIPs($d)->get() : [];
+            $d->setRelation('banned_ips', $canView ? $this->bannedIPs->getUserBannedIPs($d)->get() : new Collection());
         }
 
         return $data;

--- a/tests/integration/SerializationDataTest.php
+++ b/tests/integration/SerializationDataTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of fof/ban-ips.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\BanIPs\Tests\integration;
+
+use Carbon\Carbon;
+use Flarum\Api\Controller\AbstractListController;
+use Flarum\Api\Controller\AbstractSerializeController;
+use Flarum\Http\RequestUtil;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use FoF\BanIPs\Listeners\BannedIPData;
+use FoF\BanIPs\Listeners\BannedIPsData;
+use FoF\BanIPs\Tests\fixtures\IPAddressesTrait;
+use Laminas\Diactoros\ServerRequest;
+use Psr\Http\Message\ServerRequestInterface;
+
+class SerializationDataTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+    use IPAddressesTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-ban-ips');
+
+        $this->prepareDatabase([
+            // The fixture associates every banned IP with user_id 3.
+            'banned_ips' => $this->getBannedIPsForDB(),
+            'users'      => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'ipBanned', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'ipbanned@machine.local', 'is_email_confirmed' => 1, 'last_seen_at' => Carbon::now()->subSecond()],
+            ],
+        ]);
+    }
+
+    protected function requestAsAdmin(): ServerRequestInterface
+    {
+        $this->app();
+
+        return RequestUtil::withActor(new ServerRequest([], [], null, 'GET'), User::find(1));
+    }
+
+    /**
+     * @test
+     */
+    public function show_user_listener_sets_banned_ips_as_a_relation_not_an_attribute()
+    {
+        $request = $this->requestAsAdmin();
+        $listener = $this->app()->getContainer()->make(BannedIPData::class);
+
+        $user = User::find(3);
+        $listener($this->createMock(AbstractSerializeController::class), $user, $request);
+
+        $this->assertTrue($user->relationLoaded('banned_ips'), 'banned_ips should be set as a loaded relation');
+        $this->assertArrayNotHasKey('banned_ips', $user->getAttributes(), 'banned_ips must not be stored as a model attribute');
+        $this->assertFalse($user->isDirty(), 'the user instance must not be left dirty');
+
+        // Sanity check: the relation still carries the expected data for serialization.
+        $this->assertNotEmpty($user->getRelation('banned_ips'));
+    }
+
+    /**
+     * Reproduces the reported incompatibility: another extension calling save() on the user
+     * instance after our listener has populated its banned IPs. Previously this threw
+     * "Unknown column 'banned_ips'" because the value was stored as a model attribute.
+     *
+     * @test
+     */
+    public function user_can_still_be_saved_after_show_user_listener_runs()
+    {
+        $request = $this->requestAsAdmin();
+        $listener = $this->app()->getContainer()->make(BannedIPData::class);
+
+        $user = User::find(3);
+        $listener($this->createMock(AbstractSerializeController::class), $user, $request);
+
+        $user->save();
+
+        $this->assertNull(User::find(3)->getAttributes()['banned_ips'] ?? null);
+    }
+
+    /**
+     * @test
+     */
+    public function list_users_listener_sets_banned_ips_as_a_relation_not_an_attribute()
+    {
+        $request = $this->requestAsAdmin();
+        $listener = $this->app()->getContainer()->make(BannedIPsData::class);
+
+        $users = User::whereIn('id', [2, 3])->get();
+        $listener($this->createMock(AbstractListController::class), $users, $request);
+
+        foreach ($users as $user) {
+            $this->assertTrue($user->relationLoaded('banned_ips'), 'banned_ips should be set as a loaded relation');
+            $this->assertArrayNotHasKey('banned_ips', $user->getAttributes(), 'banned_ips must not be stored as a model attribute');
+
+            // Must not throw "Unknown column 'banned_ips'".
+            $user->save();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

When this extension is enabled, requests to the `/users` API endpoint can fail with:

```
PDOException: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'banned_ips' in 'field list'
(SQL: update `users` set `banned_ips` = ... where `id` = 3)
```

This surfaced as an incompatibility with **Kilowhat Formulaire**, but the root cause is here.

## Root cause

The serialization listeners populate a user's banned IPs via array access:

```php
$data['banned_ips'] = $canView ? $this->bannedIPs->getUserBannedIPs($data)->get() : [];
```

On an Eloquent model, `$model['key'] = ...` routes through `ArrayAccess::offsetSet()` → `setAttribute()`, so `banned_ips` is stored in the model's **attributes**, not as a relation. If any other extension then calls `$user->save()` on that same instance during the request (Formulaire does this in middleware), Eloquent tries to write a `banned_ips` column that doesn't exist, and the request 500s.

## Fix

Use `setRelation()` so the value is stored as a **loaded relation** rather than a persistable attribute, in both listeners:

- `src/Listeners/BannedIPData.php` (ShowUser / CreateUser / UpdateUser)
- `src/Listeners/BannedIPsData.php` (ListUsers / CheckIPs)

```php
$data->setRelation('banned_ips', $canView ? $this->bannedIPs->getUserBannedIPs($data)->get() : new Collection());
```

- `$user->save()` no longer sees `banned_ips` as a dirty column, so the crash is gone.
- The serializer's `hasMany('banned_ips')` reads the loaded relation, so API output is unchanged.
- The no-permission branch now sets an empty `Collection` (instead of `[]`), preserving the existing behaviour of not exposing bans to users without `viewBannedIPList` rather than lazy-loading them.

This matches the approach suggested by Formulaire's author.

## Regression test

`tests/integration/SerializationDataTest.php` invokes each listener directly and then:

- asserts the user instance is **not** left dirty and that `banned_ips` is a loaded relation, not a model attribute;
- calls `$user->save()` to mimic another extension persisting the model mid-request.

The `save()` assertions reproduce the reported `Unknown column 'banned_ips'` error on the previous code and pass with this fix (verified by temporarily reverting the change).