### PR TITLE
Fire IPWasUnbanned when a single IP is unbanned

### DIFF
--- a/src/Commands/DeleteBannedIPHandler.php
+++ b/src/Commands/DeleteBannedIPHandler.php
@@ -12,17 +12,25 @@
 namespace FoF\BanIPs\Commands;
 
 use Flarum\User\User;
+use FoF\BanIPs\Events\IPWasUnbanned;
 use FoF\BanIPs\Repositories\BannedIPRepository;
+use Illuminate\Events\Dispatcher as DispatcherEvents;
 
 class DeleteBannedIPHandler
 {
+    /**
+     * @var DispatcherEvents
+     */
+    private $events;
+
     /**
      * @var BannedIPRepository
      */
     private $bannedIPs;
 
-    public function __construct(BannedIPRepository $bannedIPs)
+    public function __construct(DispatcherEvents $events, BannedIPRepository $bannedIPs)
     {
+        $this->events = $events;
         $this->bannedIPs = $bannedIPs;
     }
 
@@ -38,5 +46,9 @@ class DeleteBannedIPHandler
         $banIP = $this->bannedIPs->findOrFail($command->bannedId);
 
         $banIP->delete();
+
+        $this->events->dispatch(
+            new IPWasUnbanned($banIP, $actor)
+        );
     }
 }

--- a/tests/integration/api/DeleteBannedIPControllerTest.php
+++ b/tests/integration/api/DeleteBannedIPControllerTest.php
@@ -15,6 +15,7 @@ use Carbon\Carbon;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use FoF\BanIPs\BannedIP;
+use FoF\BanIPs\Events\IPWasUnbanned;
 use FoF\BanIPs\Tests\fixtures\IPAddressesTrait;
 
 class DeleteBannedIPControllerTest extends TestCase
@@ -78,5 +79,24 @@ class DeleteBannedIPControllerTest extends TestCase
 
         $this->assertEquals(403, $response->getStatusCode());
         $this->assertNotNull(BannedIP::find(1));
+    }
+
+    public function test_deleting_a_banned_ip_fires_the_unbanned_event()
+    {
+        $events = [];
+
+        $this->app()->getContainer()->make('events')->listen(IPWasUnbanned::class, function (IPWasUnbanned $event) use (&$events) {
+            $events[] = $event;
+        });
+
+        $response = $this->send(
+            $this->request('DELETE', '/api/fof/ban-ips/1', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertCount(1, $events, 'IPWasUnbanned should be dispatched once when an IP is unbanned');
+        $this->assertEquals($this->getIPv4Banned()[0], $events[0]->unbannedIP->address);
     }
 }


### PR DESCRIPTION
Fixes #4.

## Problem

`IPWasUnbanned` was only dispatched when unbanning an entire **user** (`UnbanUserHandler`). When a **single IP** was unbanned — the admin panel's "unban IP" action and the forum post/user "unban (only this IP)" path, both routed through `DeleteBannedIPHandler` — the ban was deleted but **no event was fired**:

```php
$banIP = $this->bannedIPs->findOrFail($command->bannedId);
$banIP->delete();          // no IPWasUnbanned dispatched
```

So any extension subscribing to `IPWasUnbanned` (the event's only purpose) missed every single-IP unban. This has been the case since the issue was reported in 2020.

## Fix

Inject the events dispatcher into `DeleteBannedIPHandler` and dispatch `IPWasUnbanned` after deletion, mirroring `UnbanUserHandler`:

```php
$banIP->delete();

$this->events->dispatch(
    new IPWasUnbanned($banIP, $actor)
);
```

## Test

`DeleteBannedIPControllerTest::test_deleting_a_banned_ip_fires_the_unbanned_event` listens for `IPWasUnbanned`, performs `DELETE /api/fof/ban-ips/{id}`, and asserts the event fires exactly once carrying the correct IP. Verified it fails without the dispatch and passes with it.