### PR TITLE
Fix JS error when unbanning a single IP

### DIFF
--- a/js/src/common/components/UnbanIPModal.tsx
+++ b/js/src/common/components/UnbanIPModal.tsx
@@ -165,16 +165,26 @@ export default class UnbanIPModal extends BanIPModal {
   done(bannedIP?: BannedIP | ApiPayloadPlural) {
     this.loading = false;
 
-    if (this.post) delete this.post.data.relationships!.banned_ip;
+    if (this.post && this.post.data.relationships) {
+      delete this.post.data.relationships.banned_ip;
+    }
 
-    if (this.user && !this.user.data.relationships && !bannedIP) {
-      this.user.data.relationships!.banned_ips.data = [];
-      this.user.data.attributes!.isBanned = false;
-    } else if (this.user && bannedIP instanceof app.store.models.banned_ips) {
-      this.user.data.relationships!.banned_ips = {
-        data: (this.user.data.relationships!.banned_ips.data as ModelIdentifier[]).filter((e) => e.id !== (bannedIP as BannedIP).id()),
-      };
-      this.user.data.attributes!.isBanned = (this.user.data.relationships!.banned_ips.data as ModelIdentifier[]).length !== 0;
+    if (this.user && bannedIP instanceof app.store.models.banned_ips) {
+      const relationships = this.user.data.relationships;
+
+      // Only mutate the user's banned IPs relationship when it was actually loaded.
+      // When unbanning a single IP from the admin panel, the associated user (if any) is
+      // loaded as an included resource without its `banned_ips` relationship, so this would
+      // otherwise throw "Cannot read property 'banned_ips' of undefined".
+      if (relationships && relationships.banned_ips) {
+        relationships.banned_ips = {
+          data: (relationships.banned_ips.data as ModelIdentifier[]).filter((e) => e.id !== (bannedIP as BannedIP).id()),
+        };
+
+        if (this.user.data.attributes) {
+          this.user.data.attributes.isBanned = (relationships.banned_ips.data as ModelIdentifier[]).length !== 0;
+        }
+      }
     }
 
     if (bannedIP && Array.isArray((bannedIP as ApiPayloadPlural).data)) {


### PR DESCRIPTION
Fixes #5.

## Problem

Unbanning an IP with the "Only unban current IP" option (admin panel, and the forum post/user "unban this IP" path) throws a JavaScript error and leaves the modal stuck in loading mode, even though the IP is correctly deleted:

```
Uncaught TypeError: Cannot read property 'banned_ips' of undefined
TypeError: this.user.data.relationships is undefined
```

## Root cause

`UnbanIPModal::done()` assumed `this.user.data.relationships` (and its `banned_ips` entry) were always present:

```ts
this.user.data.relationships!.banned_ips = {
  data: (this.user.data.relationships!.banned_ips.data as ModelIdentifier[]).filter(...),
};
```

When unbanning a single IP, the associated user (resolved from the banned IP's `user` relation) is loaded as an *included* resource and does not carry its own `banned_ips` relationship, so `data.relationships` (or `.banned_ips`) is `undefined` and the access throws. Since `done()` threw before `hide()` ran, the modal never closed.

The TypeScript conversion preserved the bug — the `!` non-null assertions compile away and provide no runtime protection.

## Fix

- Only mutate the user's `banned_ips` relationship when it was actually loaded; otherwise skip it (the deletion already happened, and the list refreshes on redraw/reload).
- Guard the post relationship deletion the same way.
- Remove the dead first branch: its `!bannedIP` condition was never satisfied (`done()` is always called with a value), and it would itself have thrown for the same reason.

## Testing

This repo has no JS test harness, so the change is verified by `tsc` (type check passes) and the type-coverage gate (still 100%). The remaining accesses are guarded against the `undefined` relationship that caused the crash.